### PR TITLE
Updated Framework version to 4.8 and fixed a bug in the encryption comboBox

### DIFF
--- a/App.config
+++ b/App.config
@@ -2,5 +2,5 @@
 <configuration>
     <startup> 
         
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup>
 </configuration>

--- a/CabMaker.csproj
+++ b/CabMaker.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CabMaker</RootNamespace>
     <AssemblyName>CabMaker</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsWebBootstrapper>false</IsWebBootstrapper>

--- a/Form1.cs
+++ b/Form1.cs
@@ -239,7 +239,7 @@ namespace CabMaker
         private void Form1_Load(object sender, EventArgs e)
         {
             cboCompressType.Items.AddRange(Enum.GetNames(typeof(CompressionType)));
-
+            cboCompressType.SelectedIndex = 0;
             cboCompressMemory.DataSource = Constants.CompressionWindowSizes;
             cboCompressMemory.DisplayMember = "Description";
             cboCompressMemory.ValueMember = "Exponent";

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CabMaker.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CabMaker.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));


### PR DESCRIPTION
The target framework is updated to .NET Framework 4.8. 

Defaulted the none selection on the encryption combobox, as if nothing is selected (previously was empty) the makecab will exit with an error.

-Chocy