### PR TITLE
Added auto-complete extension for the output file

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -3,6 +3,7 @@
     public static class Constants
     {
         public static CompressionType DefaultCompressionType = CompressionType.MSZIP;
+        public static FileExtension FileExtension = FileExtension.CAB;
         public static CompressionWindowSize DefaultCompressionWindowSize;
 
         static Constants()

--- a/Enums.cs
+++ b/Enums.cs
@@ -9,4 +9,11 @@
         MSZIP,
         LZX
     }
+    public enum FileExtension
+    {
+        CAB,
+        WSP,
+        XSN
+
+    }
 }

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -50,32 +50,31 @@
             this.label8 = new System.Windows.Forms.Label();
             this.cboCompressType = new System.Windows.Forms.ComboBox();
             this.cboCompressMemory = new System.Windows.Forms.ComboBox();
+            this.cboFileExt = new System.Windows.Forms.ComboBox();
+            this.label9 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(18, 14);
-            this.label1.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label1.Location = new System.Drawing.Point(12, 9);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(108, 20);
+            this.label1.Size = new System.Drawing.Size(79, 13);
             this.label1.TabIndex = 0;
             this.label1.Text = "Source folder:";
             // 
             // txtSourceFolder
             // 
-            this.txtSourceFolder.Location = new System.Drawing.Point(23, 38);
-            this.txtSourceFolder.Margin = new System.Windows.Forms.Padding(5);
+            this.txtSourceFolder.Location = new System.Drawing.Point(15, 25);
             this.txtSourceFolder.Name = "txtSourceFolder";
-            this.txtSourceFolder.Size = new System.Drawing.Size(663, 26);
+            this.txtSourceFolder.Size = new System.Drawing.Size(443, 22);
             this.txtSourceFolder.TabIndex = 1;
             // 
             // btnSourceBrowse
             // 
-            this.btnSourceBrowse.Location = new System.Drawing.Point(696, 35);
-            this.btnSourceBrowse.Margin = new System.Windows.Forms.Padding(5);
+            this.btnSourceBrowse.Location = new System.Drawing.Point(464, 23);
             this.btnSourceBrowse.Name = "btnSourceBrowse";
-            this.btnSourceBrowse.Size = new System.Drawing.Size(113, 35);
+            this.btnSourceBrowse.Size = new System.Drawing.Size(75, 23);
             this.btnSourceBrowse.TabIndex = 2;
             this.btnSourceBrowse.Text = "Browse...";
             this.btnSourceBrowse.UseVisualStyleBackColor = true;
@@ -84,27 +83,24 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(18, 138);
-            this.label2.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label2.Location = new System.Drawing.Point(12, 90);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(103, 20);
+            this.label2.Size = new System.Drawing.Size(76, 13);
             this.label2.TabIndex = 4;
             this.label2.Text = "Target folder:";
             // 
             // txtTargetFolder
             // 
-            this.txtTargetFolder.Location = new System.Drawing.Point(23, 163);
-            this.txtTargetFolder.Margin = new System.Windows.Forms.Padding(5);
+            this.txtTargetFolder.Location = new System.Drawing.Point(15, 106);
             this.txtTargetFolder.Name = "txtTargetFolder";
-            this.txtTargetFolder.Size = new System.Drawing.Size(663, 26);
+            this.txtTargetFolder.Size = new System.Drawing.Size(443, 22);
             this.txtTargetFolder.TabIndex = 5;
             // 
             // btnTargetBrowse
             // 
-            this.btnTargetBrowse.Location = new System.Drawing.Point(696, 162);
-            this.btnTargetBrowse.Margin = new System.Windows.Forms.Padding(5);
+            this.btnTargetBrowse.Location = new System.Drawing.Point(464, 105);
             this.btnTargetBrowse.Name = "btnTargetBrowse";
-            this.btnTargetBrowse.Size = new System.Drawing.Size(113, 35);
+            this.btnTargetBrowse.Size = new System.Drawing.Size(75, 23);
             this.btnTargetBrowse.TabIndex = 6;
             this.btnTargetBrowse.Text = "Browse...";
             this.btnTargetBrowse.UseVisualStyleBackColor = true;
@@ -114,31 +110,28 @@
             // 
             this.txtOutput.BackColor = System.Drawing.Color.White;
             this.txtOutput.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.txtOutput.Location = new System.Drawing.Point(23, 469);
-            this.txtOutput.Margin = new System.Windows.Forms.Padding(5);
+            this.txtOutput.Location = new System.Drawing.Point(15, 305);
             this.txtOutput.Multiline = true;
             this.txtOutput.Name = "txtOutput";
             this.txtOutput.ReadOnly = true;
             this.txtOutput.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.txtOutput.Size = new System.Drawing.Size(784, 329);
+            this.txtOutput.Size = new System.Drawing.Size(524, 215);
             this.txtOutput.TabIndex = 13;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(20, 433);
-            this.label3.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label3.Location = new System.Drawing.Point(13, 281);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(62, 20);
+            this.label3.Size = new System.Drawing.Size(48, 13);
             this.label3.TabIndex = 12;
             this.label3.Text = "Output:";
             // 
             // btnRun
             // 
-            this.btnRun.Location = new System.Drawing.Point(696, 425);
-            this.btnRun.Margin = new System.Windows.Forms.Padding(5);
+            this.btnRun.Location = new System.Drawing.Point(464, 276);
             this.btnRun.Name = "btnRun";
-            this.btnRun.Size = new System.Drawing.Size(113, 35);
+            this.btnRun.Size = new System.Drawing.Size(75, 23);
             this.btnRun.TabIndex = 11;
             this.btnRun.Text = "Make CAB";
             this.btnRun.UseVisualStyleBackColor = true;
@@ -147,30 +140,28 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(18, 232);
-            this.label4.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label4.Location = new System.Drawing.Point(12, 151);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(127, 20);
+            this.label4.Size = new System.Drawing.Size(92, 13);
             this.label4.TabIndex = 7;
             this.label4.Text = "Target file name:";
             // 
             // txtFileName
             // 
-            this.txtFileName.Location = new System.Drawing.Point(23, 257);
-            this.txtFileName.Margin = new System.Windows.Forms.Padding(5);
+            this.txtFileName.Location = new System.Drawing.Point(15, 167);
             this.txtFileName.Name = "txtFileName";
-            this.txtFileName.Size = new System.Drawing.Size(355, 26);
+            this.txtFileName.Size = new System.Drawing.Size(238, 22);
             this.txtFileName.TabIndex = 8;
+            this.txtFileName.TextChanged += new System.EventHandler(this.txtFileName_TextChanged);
             // 
             // chkRecursive
             // 
             this.chkRecursive.AutoSize = true;
             this.chkRecursive.Checked = true;
             this.chkRecursive.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkRecursive.Location = new System.Drawing.Point(45, 78);
-            this.chkRecursive.Margin = new System.Windows.Forms.Padding(5);
+            this.chkRecursive.Location = new System.Drawing.Point(30, 51);
             this.chkRecursive.Name = "chkRecursive";
-            this.chkRecursive.Size = new System.Drawing.Size(375, 24);
+            this.chkRecursive.Size = new System.Drawing.Size(278, 17);
             this.chkRecursive.TabIndex = 3;
             this.chkRecursive.Text = "Include all sub-folders beneath the source folder";
             this.chkRecursive.UseVisualStyleBackColor = true;
@@ -178,10 +169,9 @@
             // label5
             // 
             this.label5.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.label5.Location = new System.Drawing.Point(24, 394);
-            this.label5.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label5.Location = new System.Drawing.Point(16, 256);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(785, 3);
+            this.label5.Size = new System.Drawing.Size(523, 2);
             this.label5.TabIndex = 10;
             // 
             // chkRemember
@@ -189,10 +179,9 @@
             this.chkRemember.AutoSize = true;
             this.chkRemember.Checked = true;
             this.chkRemember.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkRemember.Location = new System.Drawing.Point(465, 260);
-            this.chkRemember.Margin = new System.Windows.Forms.Padding(5);
+            this.chkRemember.Location = new System.Drawing.Point(310, 169);
             this.chkRemember.Name = "chkRemember";
-            this.chkRemember.Size = new System.Drawing.Size(341, 24);
+            this.chkRemember.Size = new System.Drawing.Size(245, 17);
             this.chkRemember.TabIndex = 9;
             this.chkRemember.Text = "Remember these values next time app runs";
             this.chkRemember.UseVisualStyleBackColor = true;
@@ -200,50 +189,47 @@
             // lblOutputStatus
             // 
             this.lblOutputStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblOutputStatus.Location = new System.Drawing.Point(128, 433);
-            this.lblOutputStatus.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.lblOutputStatus.Location = new System.Drawing.Point(85, 281);
             this.lblOutputStatus.Name = "lblOutputStatus";
-            this.lblOutputStatus.Size = new System.Drawing.Size(560, 26);
+            this.lblOutputStatus.Size = new System.Drawing.Size(373, 17);
             this.lblOutputStatus.TabIndex = 14;
             this.lblOutputStatus.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(20, 823);
-            this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label6.Location = new System.Drawing.Point(13, 535);
+            this.label6.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(67, 20);
+            this.label6.Size = new System.Drawing.Size(48, 13);
             this.label6.TabIndex = 15;
             this.label6.Text = "Version:";
             // 
             // lblVersion
             // 
             this.lblVersion.AutoSize = true;
-            this.lblVersion.Location = new System.Drawing.Point(94, 823);
-            this.lblVersion.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.lblVersion.Location = new System.Drawing.Point(63, 535);
+            this.lblVersion.Margin = new System.Windows.Forms.Padding(1, 0, 1, 0);
             this.lblVersion.Name = "lblVersion";
-            this.lblVersion.Size = new System.Drawing.Size(129, 20);
+            this.lblVersion.Size = new System.Drawing.Size(94, 13);
             this.lblVersion.TabIndex = 16;
             this.lblVersion.Text = "(set at form load)";
             // 
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(20, 333);
-            this.label7.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label7.Location = new System.Drawing.Point(13, 205);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(144, 20);
+            this.label7.Size = new System.Drawing.Size(103, 13);
             this.label7.TabIndex = 17;
             this.label7.Text = "Compression Type:";
             // 
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(461, 333);
-            this.label8.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label8.Location = new System.Drawing.Point(307, 216);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(166, 20);
+            this.label8.Size = new System.Drawing.Size(121, 13);
             this.label8.TabIndex = 18;
             this.label8.Text = "Compression Memory:";
             // 
@@ -251,9 +237,10 @@
             // 
             this.cboCompressType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboCompressType.FormattingEnabled = true;
-            this.cboCompressType.Location = new System.Drawing.Point(188, 330);
+            this.cboCompressType.Location = new System.Drawing.Point(125, 203);
+            this.cboCompressType.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.cboCompressType.Name = "cboCompressType";
-            this.cboCompressType.Size = new System.Drawing.Size(190, 28);
+            this.cboCompressType.Size = new System.Drawing.Size(128, 21);
             this.cboCompressType.TabIndex = 19;
             this.cboCompressType.SelectedIndexChanged += new System.EventHandler(this.cboCompressType_SelectedIndexChanged);
             // 
@@ -262,16 +249,38 @@
             this.cboCompressMemory.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboCompressMemory.Enabled = false;
             this.cboCompressMemory.FormattingEnabled = true;
-            this.cboCompressMemory.Location = new System.Drawing.Point(647, 330);
+            this.cboCompressMemory.Location = new System.Drawing.Point(431, 214);
+            this.cboCompressMemory.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.cboCompressMemory.Name = "cboCompressMemory";
-            this.cboCompressMemory.Size = new System.Drawing.Size(162, 28);
+            this.cboCompressMemory.Size = new System.Drawing.Size(109, 21);
             this.cboCompressMemory.TabIndex = 20;
+            // 
+            // cboFileExt
+            // 
+            this.cboFileExt.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboFileExt.FormattingEnabled = true;
+            this.cboFileExt.Location = new System.Drawing.Point(125, 229);
+            this.cboFileExt.Margin = new System.Windows.Forms.Padding(2);
+            this.cboFileExt.Name = "cboFileExt";
+            this.cboFileExt.Size = new System.Drawing.Size(128, 21);
+            this.cboFileExt.TabIndex = 22;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(13, 231);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(54, 13);
+            this.label9.TabIndex = 21;
+            this.label9.Text = "File Type:";
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(834, 870);
+            this.ClientSize = new System.Drawing.Size(556, 566);
+            this.Controls.Add(this.cboFileExt);
+            this.Controls.Add(this.label9);
             this.Controls.Add(this.cboCompressMemory);
             this.Controls.Add(this.cboCompressType);
             this.Controls.Add(this.label8);
@@ -295,7 +304,6 @@
             this.Controls.Add(this.label1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(5);
             this.MaximizeBox = false;
             this.Name = "MainForm";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
@@ -330,6 +338,8 @@
         private System.Windows.Forms.Label label8;
         private System.Windows.Forms.ComboBox cboCompressType;
         private System.Windows.Forms.ComboBox cboCompressMemory;
+        private System.Windows.Forms.ComboBox cboFileExt;
+        private System.Windows.Forms.Label label9;
     }
 }
 

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -10,7 +10,6 @@ namespace CabMaker
     public partial class MainForm : Form
     {
         private const int EXIT_CODE_SUCCESS = 0;
-
         public MainForm()
         {
             InitializeComponent();
@@ -44,6 +43,20 @@ namespace CabMaker
         {
             btnRun.Enabled = false;
 
+            switch (cboFileExt.SelectedIndex)
+            {
+                case 0:
+
+                    txtFileName.Text = txtFileName.Text + ".cab";
+                    break;
+                case 1:
+                    txtFileName.Text = txtFileName.Text + ".wsp";
+                    break;
+                case 2:
+                    txtFileName.Text = txtFileName.Text + ".xsn";
+                    break;
+
+            }
             lblOutputStatus.Text = "";
             lblOutputStatus.ForeColor = SystemColors.WindowText;
 
@@ -178,6 +191,7 @@ namespace CabMaker
             // Initialize drop-downs
 
             cboCompressType.Items.AddRange(Enum.GetNames(typeof(CompressionType)));
+            cboFileExt.Items.AddRange(Enum.GetNames(typeof(FileExtension)));
             cboCompressMemory.DataSource = Constants.CompressionWindowSizes;
             cboCompressMemory.DisplayMember = "Description";
             cboCompressMemory.ValueMember = "Exponent";
@@ -192,6 +206,7 @@ namespace CabMaker
             txtFileName.Text = settings.FileName;
 
             cboCompressType.SelectedItem = Enum.GetName(typeof(CompressionType), settings.CompressionType);
+            cboFileExt.SelectedItem = Enum.GetName(typeof(FileExtension), settings.FileExtension);
             cboCompressMemory.SelectedValue = settings.CompressionWindowSize;
 
             lblVersion.Text = Assembly.GetExecutingAssembly().GetName().Version.ToString(2);
@@ -203,6 +218,11 @@ namespace CabMaker
                 cboCompressType.SelectedItem as string, Constants.DefaultCompressionType);
 
             cboCompressMemory.Enabled = DdfFileBuilder.IsCompressionWindowSizeIncluded(compressionType);
+        }
+
+        private void txtFileName_TextChanged(object sender, EventArgs e)
+        {
+            return;
         }
     }
 }

--- a/UserSettings.cs
+++ b/UserSettings.cs
@@ -13,6 +13,7 @@ namespace CabMaker
         public bool IncludeSubfolders { get; set; }
         public string TargetPath { get; set; }
         public string FileName { get; set; }
+        public FileExtension FileExtension { get; set; }
         public CompressionType CompressionType { get; set; }
         public int CompressionWindowSize { get; set; }
 
@@ -23,6 +24,7 @@ namespace CabMaker
             TargetPath = "";
             FileName = "";
             CompressionType = Constants.DefaultCompressionType;
+            FileExtension = Constants.FileExtension;
             CompressionWindowSize = Constants.DefaultCompressionWindowSize.Exponent;
         }
 


### PR DESCRIPTION
CabMaker may be used not only to make .cab archives, as referenced in README 

> It's a helpful utility for scenarios like SharePoint and InfoPath development. Both of those rely on .cab files but with different file extensions (.wsp for SharePoint and .xsn for InfoPath).

And another scenario that this feature can be useful is when a user forgets to add the extension themselves, or they think that cabmaker does it automatically.

So, I added a combobox and modified the application accordingly in order to "request" from the user what file extension they want for they archive. After the user selects it (or it remains the default extension "cab") it modifies the output filename textbox with the file extension at the end. Here is a comparison between before and now
![εικόνα](https://github.com/sapientcoder/CabMaker/assets/92590193/e307b3aa-6773-4ee4-8315-e940cc3e54a6)

![εικόνα](https://github.com/sapientcoder/CabMaker/assets/92590193/6f665eb9-6d20-4a4b-b7a6-cae5e49612fe)